### PR TITLE
fix: vias improperly exported to STL

### DIFF
--- a/src/model/stl.ts
+++ b/src/model/stl.ts
@@ -3,8 +3,7 @@ import { BoxGeometry } from 'three/src/geometries/BoxGeometry.js';
 import { Group } from 'three/src/objects/Group.js';
 import { Mesh } from 'three/src/objects/Mesh.js';
 import { downloadFile } from '~/utils/download-file';
-import { layerTypes } from './layerTypes';
-import { layout } from './layout';
+import { layout, rectLayer, rectViaLayer } from './layout';
 
 export function exportSTL() {
   const exporter = new STLExporter();
@@ -12,17 +11,18 @@ export function exportSTL() {
   const scene = new Group();
 
   for (const rect of layout.rects) {
-    const layer = layerTypes.find((l) => l.name === rect.layer);
-    if (layer == null) {
+    const layer = rectLayer(rect);
+    const viaLayer = rectViaLayer(layout, rect);
+    if (!viaLayer || !layer) {
       continue;
     }
 
-    const geometry = new BoxGeometry(rect.width, rect.height, layer.crossHeight);
+    const geometry = new BoxGeometry(rect.width, rect.height, viaLayer.crossHeight);
     const cube = new Mesh(geometry);
     cube.position.set(
       rect.x + rect.width / 2,
       -(rect.y + rect.height / 2),
-      -layer.crossY - layer.crossHeight / 2,
+      -viaLayer.crossY - viaLayer.crossHeight / 2,
     );
     cube.updateMatrixWorld();
     scene.add(cube);


### PR DESCRIPTION
Updated `stl.ts` to follow (exactly the) same logic as `CrossSection.tsx`, correctly cross referencing with `layerTypes.ts` to find the required `viaVariation` and utilizing that specific variation's height.

# Reference Images
*Using Prusa Slicer to display the generated STLs, of the preset `inverter.json`*
**Old:**
<img width="1351" height="649" alt="Old STL - Side " src="https://github.com/user-attachments/assets/c78c5aef-99b6-42cd-b943-635afe17549e" />
<img width="1304" height="790" alt="Old STL - Iso" src="https://github.com/user-attachments/assets/488c0f36-8e11-4f6f-8879-f216681171a0" />

**Fixed:**
<img width="1057" height="382" alt="Fixed STL - Side" src="https://github.com/user-attachments/assets/4042c2f6-b7c7-46fb-beab-f76458276c54" />
<img width="1241" height="751" alt="Fixed STL - Iso" src="https://github.com/user-attachments/assets/888b3f78-a0dd-4141-a725-31ed37ada4cb" />
